### PR TITLE
feat: add Fish shell setup script with modern tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Git Worktree Manager 🌿
 
-> Professional git worktree management for parallel development workflows
+> Professional git worktree management for parallel development workflows with modern Fish shell setup
 
 **Author:** [@r0derik](https://x.com/r0derik) on X
 
@@ -33,11 +33,95 @@ Git Worktree Manager (`wt`) is a comprehensive Fish shell function for managing 
 - ⌨️ **Tab Completion** - Full Fish shell completion support for all commands
 - 🛡️ **Safety First** - Confirmation prompts and comprehensive validation
 
+## 🐟 Fish Shell Setup
+
+Not using Fish shell yet? Get a modern terminal experience with our automated setup script that installs Fish shell and configures it with powerful tools for development.
+
+### Quick Install (One-liner)
+
+```bash
+# Download and run the Fish setup (fetches configs from GitHub)
+curl -sL https://raw.githubusercontent.com/roderik/wt/main/setup-fish.sh | bash
+```
+
+This will download all configurations directly from the GitHub repository and set up your Fish shell environment.
+
+### What Gets Installed
+
+ The setup script installs and configures:
+
+#### 🐚 **Fish Shell**
+- **Why:** User-friendly interactive shell with powerful features like autosuggestions, web-based configuration, and excellent tab completion
+- **What:** Smart command-line shell that's easier to use than bash/zsh
+
+#### ⭐ **Starship Prompt**
+- **Why:** Fast, customizable, and intelligent prompt that shows relevant information about your current directory
+- **What:** Cross-shell prompt with git status, package versions, execution time, and more
+- **Config:** Beautiful Catppuccin Macchiato theme pre-configured
+
+#### 🛠️ **Modern CLI Tools**
+- **bat** - `cat` with syntax highlighting and Git integration
+- **eza** - Modern `ls` replacement with icons and git status
+- **ripgrep** - Ultra-fast text search (better than `grep`)
+- **fd** - User-friendly `find` alternative
+- **fzf** - Fuzzy finder for files, command history, and more
+- **lazygit** - Terminal UI for git commands
+- **lazydocker** - Terminal UI for docker management
+- **fnm** - Fast Node.js version manager
+- **git-delta** - Beautiful git diffs with syntax highlighting
+- **hexyl** - Hex viewer with colored output
+- **procs** - Modern `ps` replacement
+- **broot** - Interactive tree view with search
+
+#### 🎯 **Smart Aliases**
+Pre-configured aliases for common tasks:
+- `ls`, `ll`, `la` → Enhanced directory listings with eza
+- `g` → git shorthand
+- `gcm` → git commit -m
+- `lzg` → lazygit
+- `lzd` → lazydocker
+- `ff` → fzf with file preview
+
+### Manual Setup
+
+If you prefer to set things up manually:
+
+```bash
+# Clone the repository
+git clone https://github.com/roderik/wt.git
+cd wt
+git checkout fishsetup
+
+# Run the setup script
+./setup-fish.sh
+
+# Change your default shell to Fish
+chsh -s $(which fish)
+```
+
+### What the Setup Does
+
+1. **Installs Homebrew** (if not present) - macOS package manager
+2. **Installs Fish shell** and adds it to allowed shells
+3. **Installs modern development tools** via Homebrew
+4. **Configures Fish** with aliases, completions, and environment setup
+5. **Configures Starship** with a beautiful, informative prompt
+6. **Installs wt** (this git worktree manager) if present
+
+The script is idempotent - you can run it multiple times to update your setup.
+
+### Configuration Files
+
+The setup creates:
+- `~/.config/fish/config.fish` - Fish shell configuration
+- `~/.config/starship.toml` - Starship prompt theme
+- `~/.config/fish/functions/wt.fish` - Git worktree manager (if installed)
+
 ## Installation
 
 ### Prerequisites
 
-- [Fish Shell](https://fishshell.com/) 4.0+
+- [Fish Shell](https://fishshell.com/) 4.0+ (or use our setup script above)
 - [Git](https://git-scm.com/) 2.5+ (with worktree support)
 - At least one package manager: [Bun](https://bun.sh/), NPM, [Yarn](https://yarnpkg.com/), or [PNPM](https://pnpm.io/)
 

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -1,0 +1,82 @@
+# Fish Shell Configuration
+# Location: ~/.config/fish/config.fish
+
+# Homebrew setup (detects M-series vs Intel Macs)
+if test -e /opt/homebrew/bin/brew
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+else if test -e /usr/local/bin/brew
+    eval "$(/usr/local/bin/brew shellenv)"
+end
+
+# Fast Node Manager
+if command -q fnm
+    eval "$(fnm env --use-on-cd)"
+end
+
+# 1Password CLI completion
+if command -q op
+    op completion fish | source
+end
+
+# Environment variables
+set -x NODE_NO_WARNINGS 1
+
+# Modern command aliases
+alias dockerclean='docker rm $(docker ps -a -q); docker rmi $(docker images -q); docker volume rm $(docker volume ls -f dangling=true -q)'
+alias dc='docker compose'
+alias ls='eza -lh --group-directories-first'
+alias l='eza --git-ignore --group-directories-first'
+alias ll='eza --all --header --long --group-directories-first'
+alias llm='eza --all --header --long --sort=modified --group-directories-first'
+alias la='eza -lbhHigUmuSa'
+alias lx='eza -lbhHigUmuSa@'
+alias lt='eza --tree'
+alias tree='eza --tree'
+alias g='git'
+alias d='docker'
+alias lzg='lazygit'
+alias lzd='lazydocker'
+alias gcm='git commit -m'
+alias gcam='git commit -a -m'
+alias gcad='git commit -a --amend'
+alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
+alias n='nvim'
+alias vim='nvim'
+alias exa='eza'
+
+# Interactive session configuration
+if status is-interactive
+    # Initialize Starship prompt
+    if command -q starship
+        eval "$(starship init fish)"
+    end
+end
+
+# Bun
+if test -d "$HOME/.bun"
+    set -x BUN_INSTALL "$HOME/.bun"
+    set -x PATH $BUN_INSTALL/bin $PATH
+end
+
+# Foundry
+if test -d "$HOME/.foundry/bin"
+    fish_add_path -a "$HOME/.foundry/bin"
+end
+
+# pnpm
+if test -d "$HOME/Library/pnpm"
+    set -gx PNPM_HOME "$HOME/Library/pnpm"
+    if not string match -q -- $PNPM_HOME $PATH
+        set -gx PATH "$PNPM_HOME" $PATH
+    end
+end
+
+# Kubernetes krew
+if test -d "$HOME/.krew/bin"
+    set -gx PATH $PATH $HOME/.krew/bin
+end
+
+# User-specific configuration
+if test -f ~/.config/fish/user_config.fish
+    source ~/.config/fish/user_config.fish
+end

--- a/config/starship/starship.toml
+++ b/config/starship/starship.toml
@@ -1,0 +1,106 @@
+# Starship Configuration
+# Location: ~/.config/starship.toml
+"$schema" = 'https://starship.rs/config-schema.json'
+
+# Sets user-defined palette
+palette = "catppuccin_macchiato"
+
+[nodejs]
+detect_files = ['package.json', '.node-version', '!bunfig.toml', '!bun.lockb', '!bun.lock']
+
+[cmd_duration]
+disabled = false
+min_time = 500
+format = 'underwent [$duration](bold yellow)'
+
+[git_metrics]
+disabled = false
+added_style = 'bold blue'
+format = '[+$added]($added_style)/[-$deleted]($deleted_style) '
+
+[sudo]
+style = 'bold green'
+symbol = '👩‍💻 '
+disabled = false
+
+[kubernetes]
+disabled = false
+format = 'on [$symbol$context( \($namespace\))]($style) '
+
+[[kubernetes.contexts]]
+context_pattern = "dev.local.cluster.k8s"
+context_alias = "dev"
+
+[[kubernetes.contexts]]
+context_pattern = ".*/openshift-cluster/.*"
+context_alias = "openshift"
+
+[[kubernetes.contexts]]
+context_pattern = "gke_.*_(?P<cluster>[\\w-]+)"
+context_alias = "gke/$cluster"
+
+[[kubernetes.contexts]]
+context_pattern = "arn:aws:eks:.*/(?P<cluster>[\\w-]+)"
+context_alias = "aws/$cluster"
+
+[[kubernetes.contexts]]
+context_pattern = "aks-(?P<cluster>[\\w-]+)"
+context_alias = "aks/$cluster"
+
+[[kubernetes.contexts]]
+context_pattern = "(?P<cluster>[\\w-]+)/.*/admin"
+context_alias = "ibm/$cluster"
+
+[aws]
+disabled = true
+
+[gcloud]
+disabled = true
+
+[git_status]
+ahead = "⇡${count}"
+diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+behind = "⇣${count}"
+
+[docker_context]
+disabled = true
+
+[character]
+# Note the use of Catppuccin color 'maroon'
+success_symbol = "[[♥](green) ❯](maroon)"
+error_symbol = "[❯](red)"
+vimcmd_symbol = "[❮](green)"
+
+[directory]
+truncation_length = 4
+# Catppuccin 'lavender'
+style = "bold lavender"
+
+# palette tables should be last in the config ⚓️
+[palettes.catppuccin_macchiato]
+rosewater = "#f4dbd6"
+flamingo = "#f0c6c6"
+pink = "#f5bde6"
+mauve = "#c6a0f6"
+red = "#ed8796"
+maroon = "#ee99a0"
+peach = "#f5a97f"
+yellow = "#eed49f"
+green = "#a6da95"
+teal = "#8bd5ca"
+sky = "#91d7e3"
+sapphire = "#7dc4e4"
+blue = "#8aadf4"
+lavender = "#b7bdf8"
+text = "#cad3f5"
+subtext1 = "#b8c0e0"
+subtext0 = "#a5adcb"
+overlay2 = "#939ab7"
+overlay1 = "#8087a2"
+overlay0 = "#6e738d"
+surface2 = "#5b6078"
+surface1 = "#494d64"
+surface0 = "#363a4f"
+base = "#24273a"
+mantle = "#1e2030"
+crust = "#181926"

--- a/setup-fish.sh
+++ b/setup-fish.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🐟 Fish Shell Setup Script${NC}"
+echo -e "${BLUE}=========================${NC}"
+echo ""
+
+# Detect OS and architecture
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+if [[ "$OS" != "Darwin" ]]; then
+    echo -e "${RED}Error: This script is designed for macOS only.${NC}"
+    exit 1
+fi
+
+# Detect Homebrew path based on architecture
+if [[ "$ARCH" == "arm64" ]]; then
+    BREW_PATH="/opt/homebrew/bin/brew"
+    FISH_PATH="/opt/homebrew/bin/fish"
+else
+    BREW_PATH="/usr/local/bin/brew"
+    FISH_PATH="/usr/local/bin/fish"
+fi
+
+# Install or update Homebrew
+echo -e "${YELLOW}📦 Checking Homebrew installation...${NC}"
+if ! command -v "$BREW_PATH" &> /dev/null; then
+    echo -e "${YELLOW}Installing Homebrew...${NC}"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+else
+    echo -e "${GREEN}✓ Homebrew is already installed${NC}"
+    echo -e "${YELLOW}Updating Homebrew...${NC}"
+    "$BREW_PATH" update
+fi
+
+# Install modern tools
+echo -e "${YELLOW}📦 Installing modern development tools...${NC}"
+TOOLS=(
+    "fish"      # Fish shell
+    "starship"  # Modern prompt
+    "bat"       # Better cat
+    "chafa"     # Terminal graphics
+    "hexyl"     # Hex viewer
+    "fd"        # Better find
+    "ripgrep"   # Better grep
+    "git-delta" # Better git diff
+    "procs"     # Better ps
+    "broot"     # Better tree
+    "eza"       # Better ls (exa replacement)
+    "fnm"       # Fast Node.js version manager
+    "1password-cli" # 1Password CLI
+    "lazygit"   # Terminal UI for git
+    "lazydocker" # Terminal UI for docker
+    "fzf"       # Fuzzy finder
+)
+
+for tool in "${TOOLS[@]}"; do
+    if "$BREW_PATH" list --versions "$tool" &> /dev/null; then
+        echo -e "${GREEN}✓ $tool is already installed${NC}"
+    else
+        echo -e "${YELLOW}Installing $tool...${NC}"
+        "$BREW_PATH" install "$tool"
+    fi
+done
+
+# Add Fish to allowed shells
+echo -e "${YELLOW}🐟 Configuring Fish shell...${NC}"
+if grep -q "$FISH_PATH" /etc/shells; then
+    echo -e "${GREEN}✓ Fish shell is already in /etc/shells${NC}"
+else
+    echo -e "${YELLOW}Adding Fish to allowed shells (requires sudo)...${NC}"
+    echo "$FISH_PATH" | sudo tee -a /etc/shells > /dev/null
+    echo -e "${GREEN}✓ Fish shell added to /etc/shells${NC}"
+fi
+
+# Create config directories
+echo -e "${YELLOW}📁 Creating configuration directories...${NC}"
+mkdir -p ~/.config/fish
+mkdir -p ~/.config/starship
+
+# Detect if running from local directory or curl
+if [[ -n "${BASH_SOURCE[0]}" ]] && [[ -f "$(dirname "${BASH_SOURCE[0]}")/config/fish/config.fish" ]]; then
+    # Local installation
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    echo -e "${YELLOW}📁 Local installation detected${NC}"
+
+    # Copy Fish configuration
+    echo -e "${YELLOW}🐟 Installing Fish configuration...${NC}"
+    cp "$SCRIPT_DIR/config/fish/config.fish" ~/.config/fish/config.fish
+    echo -e "${GREEN}✓ Fish configuration installed${NC}"
+
+    # Copy Starship configuration
+    echo -e "${YELLOW}⭐ Installing Starship configuration...${NC}"
+    cp "$SCRIPT_DIR/config/starship/starship.toml" ~/.config/starship.toml
+    echo -e "${GREEN}✓ Starship configuration installed${NC}"
+
+    # Install wt if available
+    if [[ -f "$SCRIPT_DIR/wt.fish" ]]; then
+        echo -e "${YELLOW}🔧 Installing wt (git worktree manager)...${NC}"
+        mkdir -p ~/.config/fish/functions
+        cp "$SCRIPT_DIR/wt.fish" ~/.config/fish/functions/wt.fish
+        echo -e "${GREEN}✓ wt installed${NC}"
+    fi
+else
+    # Remote installation via curl
+    echo -e "${YELLOW}🌐 Remote installation - downloading configurations...${NC}"
+
+    # Base URL for raw GitHub content
+    GITHUB_BASE="https://raw.githubusercontent.com/roderik/wt/main"
+
+    # Download Fish configuration
+    echo -e "${YELLOW}🐟 Downloading Fish configuration...${NC}"
+    if curl -sL "$GITHUB_BASE/config/fish/config.fish" -o ~/.config/fish/config.fish; then
+        echo -e "${GREEN}✓ Fish configuration installed${NC}"
+    else
+        echo -e "${RED}Error: Failed to download Fish configuration${NC}"
+        exit 1
+    fi
+
+    # Download Starship configuration
+    echo -e "${YELLOW}⭐ Downloading Starship configuration...${NC}"
+    if curl -sL "$GITHUB_BASE/config/starship/starship.toml" -o ~/.config/starship.toml; then
+        echo -e "${GREEN}✓ Starship configuration installed${NC}"
+    else
+        echo -e "${RED}Error: Failed to download Starship configuration${NC}"
+        exit 1
+    fi
+
+    # Download and install wt
+    echo -e "${YELLOW}🔧 Downloading wt (git worktree manager)...${NC}"
+    mkdir -p ~/.config/fish/functions
+    if curl -sL "$GITHUB_BASE/wt.fish" -o ~/.config/fish/functions/wt.fish; then
+        echo -e "${GREEN}✓ wt installed${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Could not install wt (optional)${NC}"
+        rm -f ~/.config/fish/functions/wt.fish
+    fi
+fi
+
+# Final instructions
+echo ""
+echo -e "${GREEN}✅ Installation complete!${NC}"
+echo ""
+echo -e "${BLUE}To start using Fish shell:${NC}"
+echo "  1. Change your default shell:"
+echo "     ${YELLOW}chsh -s $FISH_PATH${NC}"
+echo ""
+echo "  2. Start a new Fish shell session:"
+echo "     ${YELLOW}$FISH_PATH${NC}"
+echo ""
+echo -e "${BLUE}Installed tools:${NC}"
+echo "  • fish      - Friendly interactive shell"
+echo "  • starship  - Cross-shell prompt"
+echo "  • bat       - Cat with syntax highlighting"
+echo "  • eza       - Modern replacement for ls"
+echo "  • ripgrep   - Fast grep alternative"
+echo "  • fd        - Fast find alternative"
+echo "  • fzf       - Fuzzy finder"
+echo "  • lazygit   - Terminal UI for git"
+echo "  • lazydocker - Terminal UI for docker"
+echo "  • fnm       - Fast Node.js version manager"
+echo "  • And more!"
+echo ""
+echo -e "${BLUE}Configuration files installed:${NC}"
+echo "  • ~/.config/fish/config.fish"
+echo "  • ~/.config/starship.toml"
+if [[ -f "$SCRIPT_DIR/wt.fish" ]]; then
+    echo "  • ~/.config/fish/functions/wt.fish"
+fi


### PR DESCRIPTION
## Summary
- Add automated Fish shell setup for users who aren't using Fish yet
- Include configuration for modern development tools and beautiful Starship prompt

## What's included

### 🐟 Fish Shell Setup Script (`setup-fish.sh`)
- Automated installation for macOS (detects M-series vs Intel)
- Installs Fish shell and configures it as an allowed shell
- Works both locally and via curl one-liner

### 🛠️ Modern CLI Tools
Installs and configures:
- **bat** - Better cat with syntax highlighting
- **eza** - Modern ls replacement
- **ripgrep** - Fast text search
- **fd** - User-friendly find
- **fzf** - Fuzzy finder
- **lazygit/lazydocker** - Terminal UIs for git/docker
- **fnm** - Fast Node.js version manager
- And more\!

### ⚙️ Configurations
- **Fish config** (`config/fish/config.fish`):
  - Smart aliases for common commands
  - Package manager detection (Bun, NPM, Yarn, PNPM)
  - Environment setup for various tools
- **Starship prompt** (`config/starship/starship.toml`):
  - Beautiful Catppuccin Macchiato theme
  - Git metrics, command duration, smart contexts
  - Node.js detection that excludes Bun projects

### 📚 Documentation
- Updated README with comprehensive Fish setup section
- Explains what each tool does and why it's useful
- One-liner installation command
- Manual setup instructions

## Installation

One-liner (will work after merge):
```bash
curl -sL https://raw.githubusercontent.com/roderik/wt/main/setup-fish.sh | bash
```

## Test plan
- [x] Run pre-commit hooks - all pass
- [x] Test Fish syntax validation
- [x] Verify script detects local vs remote installation
- [ ] Test one-liner installation after merge
- [ ] Test on fresh macOS system