### PR TITLE
fix: setup script errors for curl installations

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -116,7 +116,7 @@ if status is-interactive
 
     # Modern Fish abbreviations (expand on space)
     # Git abbreviations
-    abbr --add g 'git'
+    abbr --add g git
     abbr --add ga 'git add'
     abbr --add gaa 'git add --all'
     abbr --add gap 'git add --patch'
@@ -167,12 +167,12 @@ if status is-interactive
     abbr --add ..... 'cd ../../../..'
 
     # Docker abbreviations
-    abbr --add d 'docker'
+    abbr --add d docker
     abbr --add dc 'docker compose'
-    abbr --add lzd 'lazydocker'
+    abbr --add lzd lazydocker
 
     # Other tool abbreviations
-    abbr --add lzg 'lazygit'
+    abbr --add lzg lazygit
 
     # Additional git abbreviation
     abbr --add gcad 'git commit --all --amend'
@@ -215,7 +215,7 @@ end
 if command -q zoxide
     zoxide init fish | source
     alias cd='z'
-    alias cdi='zi'  # interactive selection
+    alias cdi='zi' # interactive selection
 end
 
 # atuin - Better shell history

--- a/setup-fish.sh
+++ b/setup-fish.sh
@@ -75,6 +75,15 @@ for tool in "${TOOLS[@]}"; do
     fi
 done
 
+# Start atuin service
+echo -e "${YELLOW}🚀 Starting atuin service...${NC}"
+if "$BREW_PATH" services list | grep -q "atuin.*started"; then
+    echo -e "${GREEN}✓ atuin service is already running${NC}"
+else
+    "$BREW_PATH" services start atuin
+    echo -e "${GREEN}✓ atuin service started${NC}"
+fi
+
 # Add Fish to allowed shells
 echo -e "${YELLOW}🐟 Configuring Fish shell...${NC}"
 if grep -q "$FISH_PATH" /etc/shells; then
@@ -91,7 +100,7 @@ mkdir -p ~/.config/fish
 mkdir -p ~/.config/starship
 
 # Detect if running from local directory or curl
-if [[ -n "${BASH_SOURCE[0]}" ]] && [[ -f "$(dirname "${BASH_SOURCE[0]}")/config/fish/config.fish" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ -f "$(dirname "${BASH_SOURCE[0]:-}")/config/fish/config.fish" ]]; then
     # Local installation
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     echo -e "${YELLOW}📁 Local installation detected${NC}"


### PR DESCRIPTION
## Summary
- Fix BASH_SOURCE[0] unbound variable error when running script via curl
- Add automatic startup of atuin service after installation
- Apply fish_indent formatting to config.fish

## Test plan
- [ ] Test local installation: `./setup-fish.sh`
- [ ] Test remote installation: `curl -sSL https://raw.githubusercontent.com/roderik/wt/main/setup-fish.sh | bash`
- [ ] Verify atuin service starts automatically after installation
- [ ] Confirm no bash errors appear during curl installation