### PR TITLE
fix: handle atuin service startup failures gracefully

### DIFF
--- a/setup-fish.sh
+++ b/setup-fish.sh
@@ -75,13 +75,19 @@ for tool in "${TOOLS[@]}"; do
     fi
 done
 
-# Start atuin service
-echo -e "${YELLOW}🚀 Starting atuin service...${NC}"
+# Start atuin service (optional, may fail on some macOS versions)
+echo -e "${YELLOW}🚀 Configuring atuin...${NC}"
 if "$BREW_PATH" services list | grep -q "atuin.*started"; then
     echo -e "${GREEN}✓ atuin service is already running${NC}"
 else
-    "$BREW_PATH" services start atuin
-    echo -e "${GREEN}✓ atuin service started${NC}"
+    # Try to start the service, but don't fail if it doesn't work
+    if "$BREW_PATH" services start atuin 2>/dev/null; then
+        echo -e "${GREEN}✓ atuin service started${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Could not start atuin service automatically${NC}"
+        echo -e "${YELLOW}   This is normal on some macOS versions. Atuin will still work in your shell.${NC}"
+        echo -e "${YELLOW}   To manually start atuin daemon if needed: atuin daemon${NC}"
+    fi
 fi
 
 # Add Fish to allowed shells


### PR DESCRIPTION
## Summary
- Handles atuin service startup failures that occur on some macOS versions
- Prevents the setup script from appearing to fail when this is actually a non-critical issue

## Problem
Users were seeing this error during Fish shell setup:
```
Bootstrap failed: 5: Input/output error
Error: Failure while executing; `/bin/launchctl bootstrap gui/501 /Users/roderik/Library/LaunchAgents/homebrew.mxcl.atuin.plist` exited with 5.
```

This is a known issue with launchctl on newer macOS versions and doesn't actually prevent atuin from working in the shell.

## Solution
- Suppress the error output when starting the atuin service
- Continue the setup process even if the service fails to start
- Show an informative warning message explaining this is normal
- Provide the manual command (`atuin daemon`) for users who need it

## Test Plan
- [ ] Run setup script on macOS where atuin service fails to start
- [ ] Verify setup continues successfully
- [ ] Verify atuin still works in Fish shell despite service not running
- [ ] Verify the warning message is clear and helpful