### PR TITLE
feat: configure worktree branches to track their own remote branches

### DIFF
--- a/wt.fish
+++ b/wt.fish
@@ -272,6 +272,17 @@ function _wt_new --description "Create new worktree"
         echo "📁 Location: "(pwd)
         echo "🌿 Branch: "(git branch --show-current)
 
+        # Set up branch to track its own remote branch
+        echo "Setting up remote tracking..."
+        if git branch --set-upstream-to="origin/$branch_name" "$branch_name" 2>/dev/null
+            echo "✅ Branch will push to origin/$branch_name"
+        else
+            # If the remote branch doesn't exist yet, configure push behavior
+            git config "branch.$branch_name.remote" origin
+            git config "branch.$branch_name.merge" "refs/heads/$branch_name"
+            echo "✅ Branch configured to push to origin/$branch_name (will create remote branch on first push)"
+        end
+
         # Check for package manager files and run install
         if test -f "package.json"
             echo ""


### PR DESCRIPTION
## Summary
- Fixes issue where `wt new` branches track the source branch (e.g., main) instead of their own remote branch
- Prevents accidental pushes to main branch when working in worktrees
- Adds automatic remote tracking configuration after worktree creation

## Changes
When creating a new worktree with `wt new <branch>`, the tool now:
1. Creates the worktree and branch as before
2. Configures the branch to track `origin/<branch>` instead of the source branch
3. If the remote branch doesn't exist yet, sets up git config to push to the correct remote branch on first push
4. Provides clear user feedback about the tracking configuration

## Test plan
- [x] Run existing test suite with `./run_tests.fish` - all tests pass
- [x] Manually test `wt new test-branch` and verify with `git branch -vv` that it tracks `origin/test-branch`
- [x] Verify git config with `git config --get-regexp "branch.test-branch.*"`
- [x] Test that `git push` works correctly and creates the remote branch