### PR TITLE
feat: add editor launch options to wt new command

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -21,7 +21,7 @@ end
 # Environment variables
 set -gx NODE_NO_WARNINGS 1
 
-# Claude 
+# Claude
 set -gx ENABLE_BACKGROUND_TASKS 1
 
 # Default editor

--- a/tests/test_wt_new.fish
+++ b/tests/test_wt_new.fish
@@ -243,6 +243,65 @@ function test_wt_new_fetches_from_origin
     test_pass
 end
 
+function test_wt_new_editor_options
+    test_case "wt new - editor launch options"
+
+    cd $TEST_TEMP_DIR/test_repo
+    
+    # Test help shows editor options
+    set output (wt new 2>&1)
+    assert_contains "$output" "--claude" "Should show --claude option"
+    assert_contains "$output" "--cursor" "Should show --cursor option"
+    assert_contains "$output" "--all" "Should show --all option"
+    assert_contains "$output" "--none" "Should show --none option"
+    
+    test_pass
+end
+
+function test_wt_new_with_none_option
+    test_case "wt new --none - creates worktree without launching editor"
+
+    cd $TEST_TEMP_DIR/test_repo
+    
+    # Create worktree with --none option
+    set output (wt new feature-no-editor --none 2>&1)
+    assert_success "Should create worktree successfully"
+    
+    # Verify worktree was created
+    assert_branch_exists feature-no-editor "Branch should exist"
+    
+    # Verify no editor launch messages (use string match to check they're NOT present)
+    if string match -q "*Launching Cursor*" $output
+        echo ""
+        echo "✗ Test failed: Output should not contain 'Launching Cursor'"
+        return 1
+    end
+    if string match -q "*Launching Claude*" $output
+        echo ""
+        echo "✗ Test failed: Output should not contain 'Launching Claude'"
+        return 1
+    end
+    
+    test_pass
+end
+
+
+function test_wt_new_editor_options_with_from
+    test_case "wt new - editor options work with --from"
+
+    cd $TEST_TEMP_DIR/test_repo
+    
+    # Create a tag to use as ref
+    git tag v1.0.0
+    
+    # Test --none option with --from
+    wt new feature-from-tag --from v1.0.0 --none
+    assert_success "Should create worktree with --from and --none"
+    assert_branch_exists feature-from-tag "Branch should exist"
+    
+    test_pass
+end
+
 # Run all tests
 test_wt_new_basic
 test_wt_new_from_ref
@@ -256,3 +315,6 @@ test_wt_new_existing_worktree_path
 test_wt_new_creates_worktrees_dir
 test_wt_new_default_from_main
 test_wt_new_fetches_from_origin
+test_wt_new_editor_options
+test_wt_new_with_none_option
+test_wt_new_editor_options_with_from

--- a/tests/test_wt_new.fish
+++ b/tests/test_wt_new.fish
@@ -247,14 +247,14 @@ function test_wt_new_editor_options
     test_case "wt new - editor launch options"
 
     cd $TEST_TEMP_DIR/test_repo
-    
+
     # Test help shows editor options
     set output (wt new 2>&1)
-    assert_contains "$output" "--claude" "Should show --claude option"
-    assert_contains "$output" "--cursor" "Should show --cursor option"
-    assert_contains "$output" "--all" "Should show --all option"
-    assert_contains "$output" "--none" "Should show --none option"
-    
+    assert_contains "$output" --claude "Should show --claude option"
+    assert_contains "$output" --cursor "Should show --cursor option"
+    assert_contains "$output" --all "Should show --all option"
+    assert_contains "$output" --none "Should show --none option"
+
     test_pass
 end
 
@@ -262,14 +262,14 @@ function test_wt_new_with_none_option
     test_case "wt new --none - creates worktree without launching editor"
 
     cd $TEST_TEMP_DIR/test_repo
-    
+
     # Create worktree with --none option
     set output (wt new feature-no-editor --none 2>&1)
     assert_success "Should create worktree successfully"
-    
+
     # Verify worktree was created
     assert_branch_exists feature-no-editor "Branch should exist"
-    
+
     # Verify no editor launch messages (use string match to check they're NOT present)
     if string match -q "*Launching Cursor*" $output
         echo ""
@@ -281,24 +281,23 @@ function test_wt_new_with_none_option
         echo "✗ Test failed: Output should not contain 'Launching Claude'"
         return 1
     end
-    
+
     test_pass
 end
-
 
 function test_wt_new_editor_options_with_from
     test_case "wt new - editor options work with --from"
 
     cd $TEST_TEMP_DIR/test_repo
-    
+
     # Create a tag to use as ref
     git tag v1.0.0
-    
+
     # Test --none option with --from
     wt new feature-from-tag --from v1.0.0 --none
     assert_success "Should create worktree with --from and --none"
     assert_branch_exists feature-from-tag "Branch should exist"
-    
+
     test_pass
 end
 

--- a/wt.fish
+++ b/wt.fish
@@ -194,6 +194,9 @@ function _wt_new --description "Create new worktree"
                     echo "Error: --from requires a ref argument"
                     return 1
                 end
+                # Skip the extra increment at the bottom of the loop
+                set i (math $i + 1)
+                continue
             case --claude
                 set launch_claude true
                 set launch_cursor false


### PR DESCRIPTION
## Summary
- Add optional editor launch parameters to the `wt new` command
- Users can now automatically open their preferred editor after creating a worktree
- No editor is launched by default (previous behavior was preserved)

## New Options
- `--claude`: Launch Claude Code after worktree creation
- `--cursor`: Launch Cursor after worktree creation
- `--all`: Launch both Claude and Cursor
- `--none`: Explicitly prevent any editor launch (useful for scripts)

## Examples
```bash
# Create worktree without launching editor (default)
wt new feature-auth

# Create worktree and launch Claude
wt new api-fix --claude

# Create worktree and launch Cursor
wt new ui-update --cursor

# Create worktree and launch both editors
wt new backend --all

# Create worktree from specific ref with editor
wt new hotfix --from v1.0.0 --cursor
```

## Test Plan
- [x] Added tests for new editor options
- [x] Verified --none option prevents editor launch
- [x] Tested editor options work with --from parameter
- [x] Updated help documentation and examples
- [x] Syntax validation passes (fish -n)
- [x] Code properly formatted with fish_indent