### PR TITLE
feat: add CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1 to fish config

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -23,6 +23,7 @@ set -gx NODE_NO_WARNINGS 1
 
 # Claude
 set -gx ENABLE_BACKGROUND_TASKS 1
+set -gx CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR 1
 
 # Default editor
 set -gx EDITOR nvim


### PR DESCRIPTION
## Summary
Add `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1` environment variable to the fish shell configuration.

## Changes
- Added the environment variable to `config/fish/config.fish` in the Claude configuration section
- This tells Claude Code to maintain the project working directory when executing bash commands

## Benefits
- Improves development experience when using Claude Code
- Ensures bash commands run in the correct context
- Follows Claude Code best practices for project-based workflows

## Test plan
- [ ] Verify fish config loads without errors
- [ ] Test Claude Code bash command execution maintains working directory