### PR TITLE
fix: ensure editors launch with Fish shell environment

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -23,6 +23,7 @@ set -gx NODE_NO_WARNINGS 1
 
 # Claude
 set -gx ENABLE_BACKGROUND_TASKS 1
+set -gx CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR 1
 
 # Default editor
 set -gx EDITOR nvim

--- a/wt.fish
+++ b/wt.fish
@@ -62,17 +62,17 @@ function wt --description "Git worktree management"
         case --claude
             # Launch Claude with dangerously skip permissions
             echo "Launching Claude Code..."
-            claude --dangerously-skip-permissions
+            env SHELL=(which fish) claude --dangerously-skip-permissions
         case --cursor
             # Launch Cursor in current directory
             echo "Launching Cursor..."
-            cursor .
+            env SHELL=(which fish) cursor .
         case --all
             # Launch both editors - Cursor first (UI), then Claude (terminal)
             echo "Launching Cursor..."
-            cursor .
+            env SHELL=(which fish) cursor .
             echo "Launching Claude Code..."
-            claude --dangerously-skip-permissions
+            env SHELL=(which fish) claude --dangerously-skip-permissions
         case '*'
             echo "Error: Unknown subcommand '$subcommand'"
             echo "Run 'wt help' for usage information"
@@ -370,17 +370,17 @@ function _wt_new --description "Create new worktree"
                 # Launch both editors
                 echo ""
                 echo "Launching Cursor..."
-                cursor .
+                env SHELL=(which fish) cursor .
                 echo "Launching Claude Code..."
-                claude --dangerously-skip-permissions
+                env SHELL=(which fish) claude --dangerously-skip-permissions
             else if test $launch_cursor = true
                 echo ""
                 echo "Launching Cursor..."
-                cursor .
+                env SHELL=(which fish) cursor .
             else if test $launch_claude = true
                 echo ""
                 echo "Launching Claude Code..."
-                claude --dangerously-skip-permissions
+                env SHELL=(which fish) claude --dangerously-skip-permissions
             end
         end
     else


### PR DESCRIPTION
## Summary
- Fix editors launching with bash instead of Fish shell
- Set SHELL environment variable when launching Cursor and Claude

## Background
When launching editors via `wt new` or standalone commands (`wt --claude`, `wt --cursor`), the editors would start with the system default shell (bash) instead of the user's Fish shell environment.

## Changes
- Added `env SHELL=(which fish)` prefix to all editor launch commands
- Affects both standalone editor commands (`--claude`, `--cursor`, `--all`)  
- Affects editor launches in `wt new` command

## Test plan
- [x] Test `wt --claude` launches with Fish shell
- [x] Test `wt --cursor` launches with Fish shell  
- [x] Test `wt new --claude` launches with Fish shell
- [x] Test `wt new --cursor` launches with Fish shell
- [x] Test `wt --all` launches both editors with Fish shell