### PR TITLE
feat: check for vt installation before running claude command

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -112,7 +112,11 @@ alias exa='eza'
 
 # Claude function to avoid infinite recursion
 function claude --description 'Claude Code with skip permissions'
-    command claude --dangerously-skip-permissions $argv
+    if command -q vt
+        vt claude --dangerously-skip-permissions $argv
+    else
+        command claude --dangerously-skip-permissions $argv
+    end
 end
 
 # Interactive session configuration


### PR DESCRIPTION
## Summary
- Modified the claude function in config.fish to check if 'vt' is installed
- If 'vt' is available, the claude command is prefixed with 'vt'
- Maintains backward compatibility when 'vt' is not installed

## Changes
The claude function now uses `command -q vt` to check if the 'vt' command is available. This allows users with 'vt' installed to benefit from its features while ensuring the function continues to work for users without it.

## Test plan
- [ ] Test with 'vt' installed: Verify claude runs with 'vt' prefix
- [ ] Test without 'vt' installed: Verify claude runs normally
- [ ] Ensure the --dangerously-skip-permissions flag is still passed correctly